### PR TITLE
Use the module/package namespaced logger

### DIFF
--- a/src/miniboa/async.py
+++ b/src/miniboa/async.py
@@ -15,6 +15,7 @@ from .telnet import TelnetClient
 # Cap sockets to 1000 on UNIX because you can only have 1024 file descriptors
 MAX_CONNECTIONS = 500 if sys.platform == 'win32' else 1000
 
+LOG = logging.getLogger(__name__)
 
 # Dummy Connection Handlers
 
@@ -22,7 +23,7 @@ def _on_connect(client):
     """
     Placeholder new connection handler.
     """
-    logging.info("++ Opened connection to {}, sending greeting...".format(client.addrport()))
+    LOG.info("++ Opened connection to {}, sending greeting...".format(client.addrport()))
     client.send("Hello, my friend. Stay awhile and listen.\n")
 
 
@@ -30,7 +31,7 @@ def _on_disconnect(client):
     """
     Placeholder lost connection handler.
     """
-    logging.info("-- Lost connection to %s".format(client.addrport()))
+    LOG.info("-- Lost connection to %s".format(client.addrport()))
 
 
 # Telnet Server
@@ -89,7 +90,7 @@ class TelnetServer(object):
             server_socket.bind((address, port))
             server_socket.listen(5)
         except socket.error as err:
-            logging.critical("Unable to create the server socket: " + str(err))
+            LOG.critical("Unable to create the server socket: " + str(err))
             raise
 
         self.server_socket = server_socket
@@ -154,7 +155,7 @@ class TelnetServer(object):
                                                 self.timeout)
         except select.error as err:
             # If we can't even use select(), game over man, game over
-            logging.critical("SELECT socket error '{}'".format(str(err)))
+            LOG.critical("SELECT socket error '{}'".format(str(err)))
             raise
 
         # Process socket file descriptors with data to recieve
@@ -166,12 +167,12 @@ class TelnetServer(object):
                 try:
                     sock, addr_tup = self.server_socket.accept()
                 except socket.error as err:
-                    logging.error("ACCEPT socket error '{}:{}'.".format(err[0], err[1]))
+                    LOG.error("ACCEPT socket error '{}:{}'.".format(err[0], err[1]))
                     continue
 
                 # Check for maximum connections
                 if self.client_count() >= self.max_connections:
-                    logging.warning("Refusing new connection, maximum already in use.")
+                    LOG.warning("Refusing new connection, maximum already in use.")
                     sock.close()
                     continue
 


### PR DESCRIPTION
It is a bad habit to use the root logger in
packages because it makes it impossible for consumers
of a library to specify logging levels for just say
that library.

So this switches to using the right namespaced
logger (and not the root logger) in the various
places the root logger was used.