### PR TITLE
Add Python 3.7 to trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Topic :: Software Development :: Libraries"
 ]
 INSTALL_REQUIRES = []


### PR DESCRIPTION
Really a request for a new release - would help to run Travis with Python 3.7 for https://github.com/linkchecker/linkchecker.
Thanks (by all means don't merge this PR if it is easier to make the change yourself, nothing original here).
