### PR TITLE
Fix terminal type RFC number in docstring

### DIFF
--- a/src/miniboa/telnet.py
+++ b/src/miniboa/telnet.py
@@ -253,7 +253,7 @@ class TelnetClient(object):
     def request_terminal_type(self):
         """
         Begins the Telnet negotiations to request the terminal type from
-        the client.  See RFC 779.
+        the client.  See RFC 884.
         """
         self._iac_do(TTYPE)
         self._note_reply_pending(TTYPE, True)


### PR DESCRIPTION
I found a small typo, it looks like an RFC number got mixed up in the docstrings:

``RFC 779 (TELNET SEND-LOCATION Option)`` should be ``RFC 884 (TELNET TERMINAL TYPE OPTION)``